### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/github-samples/turn-based-game-mcp/security/code-scanning/2](https://github.com/github-samples/turn-based-game-mcp/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/ci.yml`. The block should be placed at the root level (above `jobs:`) to apply to all jobs in the workflow. The minimal required permission for the current steps is `contents: read`, which allows the workflow to read repository contents but not write to them. No additional permissions are needed for the current steps. This change does not affect existing functionality and improves security by limiting the GITHUB_TOKEN permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
